### PR TITLE
Make the config file work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Trellis Redis 
+Trellis Redis
 =========
 
 Ansible role to add Redis to Trellis server provisioning
@@ -11,8 +11,8 @@ Get Started
 Add the role to the requirements.yml file of Trellis :
 ```yaml
 - name: trellis-redis
-  src: jasonsbarr.trellis-redis
-  version: 0.2.5
+  src: marksabbath.trellis_redis
+  version: 0.2.6
 ```
 
 Run `ansible-galaxy install -r requirements.yml` to install the new role.<br>

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,11 @@
 # Basic config options
 
 redis_config_path: /etc/redis
-redis_daemonize: yes
+redis_daemonize: 'yes'
 redis_pidfile: /run/redis/redis-server.pid
 redis_port: 6379
-redis_unixsocket: ""
-redis_requirepass: ""
-redis_tcp_backlog: 511
+redis_unixsocket: ''
+redis_requirepass: ''
 redis_bind: 127.0.0.1
 redis_timeout: 0
 redis_tcp_keepalive: 0
@@ -19,9 +18,9 @@ redis_save:
   - 300 10
   - 60 10000
 
-redis_stop_writes_on_bgsave_error: yes
-redis_rdbcompression: yes
-redis_rdbchecksum: yes
+redis_stop_writes_on_bgsave_error: 'yes'
+redis_rdbcompression: 'yes'
+redis_rdbchecksum: 'yes'
 redis_dbfilename: dump.rdb
 redis_dir: /var/lib/redis
 redis_maxclients: 10000
@@ -31,13 +30,13 @@ redis_maxmemory: 128mb
 redis_maxmemory_policy: noeviction
 redis_maxmemory_samples: 3
 
-redis_appendonly: no
+redis_appendonly: 'no'
 redis_appendfilename: appendonly.aof
 redis_appendfsync: everysec
-redis_no_appendfsync_on_rewrite: no
+redis_no_appendfsync_on_rewrite: 'no'
 redis_auto_aof_rewrite_percentage: 100
 redis_auto_aof_rewrite_min_size: 128mb
-redis_aof_load_truncated: yes
+redis_aof_load_truncated: 'yes'
 redis_lua_time_limit: 5000
 redis_slowlog_slower_than: 10000
 redis_slowlog_max_len: 128
@@ -51,10 +50,10 @@ redis_set_max_intset_entries: 512
 redis_zset_max_ziplist_entries: 128
 redis_zset_max_ziplist_value: 64
 redis_hll_sparse_max_bytes: 3000
-redis_activerehashing: yes
+redis_activerehashing: 'yes'
 
 redis_client_output_buffer_limit:
   - normal 0 0 0
 
 redis_hz: 10
-redis_aof_rewrite_incremental_fsync: yes
+redis_aof_rewrite_incremental_fsync: 'yes'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,5 +16,5 @@
 
 - name: Restart php-fpm
   service:
-    name: php7.2-fpm
+    name: php7.3-fpm
     state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,5 +16,5 @@
 
 - name: Restart php-fpm
   service:
-    name: php7.3-fpm
+    name: php7.4-fpm
     state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Configure Redis
   template:
     src: redis.conf.j2
-    dest: "{{ redis_config_path }}"
+    dest: "{{ redis_config_path }}/redis.conf"
     mode: 0640
   notify: Restart Redis
 

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -12,7 +12,6 @@ unixsocket {{ redis_unixsocket }}
 requirepass {{ redis_requirepass }}
 {% endif %}
 
-tcp_backlog {{ redis_tcp_backlog }}
 bind {{ redis_bind }}
 timeout {{ redis_timeout }}
 tcp-keepalive {{ redis_tcp_keepalive }}


### PR DESCRIPTION
This PR brings to `trellis-redis` the ability to properly add the file `redis.conf` using its defaults. It also removes the `tcp_backlog` since redis does not recognize it as an option.

Closes #2 